### PR TITLE
Initial API routes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *.pyc
 db/app.db
+.cache/

--- a/HACKING.md
+++ b/HACKING.md
@@ -10,8 +10,31 @@ Python projcts and so avoid versioning conflicts.  We recommend [Conda], but
 Having set up and activated a virtual environment for Sagittariidae, install
 the required packages:
 ```
-pip install -r requirements.txt
+$ pip install -r requirements.txt
 ```
+
+## Testing
+To run the tests and get a nice report:
+
+```
+$ py.test
+```
+
+Or, to get more helpful output during development:
+
+```
+$ py.test --quiet --capture=no --tb=short
+```
+where:
+
+* `--quiet`: less verbose/pretty reporting
+* `--capture=no`: do not capture STDOUT and STDERR
+* `--tb=short`: don't overwhelm me with exception traces
+
+`py.test -h` for more details.
+
+Please extend test coverage to any new functionality that you add and make sure
+that the tests are all green before checking in changes.
 
 ## Development server
 

--- a/app/models.py
+++ b/app/models.py
@@ -12,6 +12,11 @@ def dictify(model):
                 if not kv[0].startswith('_'))
 
 
+def jsonize_models(models):
+    """Return a list of model instances as a JSON array."""
+    return json.dumps([dictify(m) for m in models])
+
+
 class Project(db.Model):
     __tablename__ = 'projects'
     id = Column('project_id', Integer, primary_key=True)
@@ -28,13 +33,13 @@ class Project(db.Model):
 
 def get_projects():
     """
-    Returns an array of JSON objects, with each element representing a project.
+    Returns a JSON array of projects.
     """
     try:
         projects = Project.query.all()
     except OperationalError:
         return ''
-    return json.dumps([dictify(p) for p in projects])
+    return jsonize_models(projects)
 
 
 def add_project(name, sample_mask):
@@ -115,13 +120,13 @@ class Method(db.Model):
 
 def get_methods():
     """
-    Returns a newline-separated JSON of all methods.
+    Returns a JSON array of methods.
     """
     try:
         methods = Method.query.all()
     except OperationalError:
         return ''
-    return '\n'.join([jsonize(m) for m in methods])
+    return jsonize_models(methods)
 
 
 def add_method(name, description):

--- a/app/models.py
+++ b/app/models.py
@@ -6,13 +6,10 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 import json
 
 
-def jsonize(model):
-    """JSONize a model."""
-    return json.dumps(
-        dict(kv for kv in iter(model.__dict__.items())
-             if not kv[0].startswith('_')),
-        indent=4
-    )
+def dictify(model):
+    """Return a model as a dictionary"""
+    return dict(kv for kv in iter(model.__dict__.items())
+                if not kv[0].startswith('_'))
 
 
 class Project(db.Model):
@@ -31,13 +28,13 @@ class Project(db.Model):
 
 def get_projects():
     """
-    Returns a newline-separated JSON of all projects.
+    Returns an array of JSON objects, with each element representing a project.
     """
     try:
         projects = Project.query.all()
     except OperationalError:
         return ''
-    return '\n'.join([jsonize(p) for p in projects])
+    return json.dumps([dictify(p) for p in projects])
 
 
 def add_project(name, sample_mask):

--- a/app/views.py
+++ b/app/views.py
@@ -12,6 +12,11 @@ def projects():
     return models.get_projects()
 
 
+@app.route('/methods')
+def methods():
+    return models.get_methods()
+
+
 @app.route('/index')
 def index():
     ifile = 'layout/index.html'

--- a/app/views.py
+++ b/app/views.py
@@ -4,7 +4,12 @@ from app import app, models
 
 @app.route('/')
 def root():
-    return "Hello, world!"
+    return 'Hello, world!'
+
+
+@app.route('/projects')
+def projects():
+    return models.get_projects()
 
 
 @app.route('/index')

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
 pbr==1.10.0
+py==1.4.31
+pytest==2.9.2
 python-openid==2.2.5
 pytz==2016.4
 six==1.10.0

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -44,7 +44,17 @@ def test_0_projects(ws):
 
 
 def test_1_projects(ws):
-    models.add_project('project3', '###')
+    name = 'project3'
+    mask = '###'
+    models.add_project(name, mask)
     rsp = decode_json_string(ws.get('/projects').data)
     assert len(rsp) == 1
-    assert rsp[0] == {'id': 1, 'name': 'project3', 'sample_mask': '###'}
+    assert rsp[0] == {'id': 1, 'name': name, 'sample_mask': mask}
+
+def test_1_methods(ws):
+    name = 'method0'
+    desc = 'placeholder description'
+    models.add_method(name, desc)
+    rsp = decode_json_string(ws.get('/methods').data)
+    assert len(rsp) == 1
+    assert rsp[0] == {'id':1, 'name':name, 'description':desc}

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -1,0 +1,50 @@
+
+from StringIO import StringIO
+import json
+import os
+import pytest
+import tempfile
+
+import app
+from app import models
+
+
+@pytest.fixture(scope='function')
+def ws(request):
+    flask_app = app.app.app
+    # Yuck!  Reeeally have to fix the app name!
+
+    fd, fn = tempfile.mkstemp()
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + fn
+    flask_app.config['TESTING'] = True
+    inst = flask_app.test_client()
+    with flask_app.app_context():
+        # db initialization goes here
+        pass
+
+    def fin():
+        os.close(fd)
+        os.unlink(fn)
+    request.addfinalizer(fin)
+    return inst
+
+
+def decode_json_string(s):
+    return json.load(StringIO(s))
+
+
+def test_0(ws):
+    rsp = ws.get('/')
+    assert rsp.data == b'Hello, world!'
+
+
+def test_0_projects(ws):
+    rsp = ws.get('/projects')
+    assert rsp.data is ''
+
+
+def test_1_projects(ws):
+    models.add_project('project3', '###')
+    rsp = decode_json_string(ws.get('/projects').data)
+    assert len(rsp) == 1
+    assert rsp[0] == {'id': 1, 'name': 'project3', 'sample_mask': '###'}

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,0 +1,10 @@
+
+import pytest
+
+from app.models import Project
+from app.models import dictify
+
+
+def test_dictify():
+    p = Project(id=0, name='project', sample_mask='###')
+    assert dictify(p) == {'id':0, 'name':'project', 'sample_mask':'###'}


### PR DESCRIPTION
This is a first small step on the road to exposing the Sagittariidae web service API.  Two routes for API functions that return the low-velocity "static" data (i.e. data that don't typically change frequently; projects and methods aren't truly static, but change infrequently enough that they can be thought of almost as configuration data; the distinction isn't really important and serves only as a way to label the data that are being used to get things working initially as the API in built up incrementally).  

The most significant change is to how the backend functions return collections.  Rather than a newline separated string of JSON objects, they now return a serialised JSON array.  This makes it possible to transform the entire payload in a single pass on both the client and the server.  It also makes us compatible with web libraries/frameworks that expect to be able to process the entire request/response payload as a single JSON document (which is most of them, including Flask).

Testing infrastructure (via Pytest) and some initial testing has also been put into place.
