### PR TITLE
Identify resources by an obfuscated ID (rather than the DB-allocated ID) in the API.

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,0 +1,10 @@
+
+class NotFound(Exception):
+    status_code = 404
+
+    def __init__(self, res_type, res_name):
+        self.message = 'The {type:} "{name:}" could not be found.'.format(
+            type=res_type, name=res_name)
+
+    def to_dict(self):
+        return {'message': self.message}

--- a/app/models.py
+++ b/app/models.py
@@ -1,15 +1,89 @@
-from app import app, db
-from sqlalchemy import ForeignKey, Column, String, Text, Integer
-from sqlalchemy.orm import relationship
-from sqlalchemy.exc import OperationalError, IntegrityError
-from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
+
+import hashids
 import json
+import re
+import sqlalchemy.types as types
+
+from sqlalchemy                import ForeignKey, Column, String, Text, Integer
+from sqlalchemy                import event
+from sqlalchemy.exc            import OperationalError, IntegrityError
+from sqlalchemy.orm            import Session
+from sqlalchemy.orm            import relationship
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.orm.exc        import NoResultFound, MultipleResultsFound
+from urllib                    import quote
+
+from app import app, db
+
+
+BAD_URI_PAT  = re.compile("%.{2}|\/|_")
+COLLAPSE_PAT = re.compile("-{2,}")
+
+
+@event.listens_for(Session, 'after_flush_postexec')
+def inject_obfuscated_id_after_flush_postexec(session, flush_context):
+    def inject_obfuscated_id(m):
+        if m.obfuscated_id is None:
+            m.obfuscated_id = m.__hashidgen__.encode(m.id)
+        return m
+    return [inject_obfuscated_id(m) for m in session.identity_map.values()]
+
+
+def with_transaction(session, f):
+    """
+    Execute `f` in a DB transaction.  If `f` completes successfully, the
+    transaction is committed, otherwise an error is raised and the transaction
+    is rolled back.
+
+    `f` must accept a single argument: the database session instance.
+    """
+    try:
+        f(session)
+        session.commit()
+    except Exception, e:
+        session.rollback()
+        raise e
+
+
+def uri_name(name):
+    """
+    Convert the name of a resource (like a project or sample) into a
+    URI-friendly form.  This function has strong opinions about what a "good"
+    URI ID is, and will complain if the ID cannot be rendered in an acceptable
+    form.  In particular, it should not contain any characters that need to be
+    escaped; cf. `urllib.quote()`.
+    """
+    # URI-escape special characters
+    new_name = quote(name.lower().replace(" ", "-"))
+    # Convert escapes into underscores; i.e. foo%20bar -> foo-bar
+    new_name = re.sub(BAD_URI_PAT, '-', new_name)
+    # Collapse multiple consecutive hyphens; i.e. foo---bar -> foo-bar
+    new_name = re.sub(COLLAPSE_PAT, '-', new_name)
+    # And return our pretty new identifier
+    return new_name
 
 
 def dictify(model):
-    """Return a model as a dictionary"""
-    return dict(kv for kv in iter(model.__dict__.items())
-                if not kv[0].startswith('_'))
+    """
+    Return a model as a dictionary. 'Private' attributes are removed and
+    underscores are replaced with more hyphens in attribute names, making for
+    more aesthetically pleasing HTTP data maps.
+    """
+    assert hasattr(model, 'id')
+    assert model.id is not None, 'Model\'s ID may not be None'
+    assert hasattr(model, 'obfuscated_id')
+    assert model.obfuscated_id is not None, 'Model\'s obfuscated ID may not be None'
+
+    def tr(kv):
+        return (kv[0].replace('_', '-'), kv[1])
+    d = dict(tr(kv) for kv in iter(model.__dict__.items())
+             if not kv[0].startswith('_'))
+    if d.has_key('name'):
+        d['id'] = '-'.join([d['obfuscated-id'], uri_name(d['name'])])
+    else:
+        d['id'] = d['obfuscated-id']
+    del d['obfuscated-id']
+    return d
 
 
 def jsonize_models(models):
@@ -17,18 +91,63 @@ def jsonize_models(models):
     return json.dumps([dictify(m) for m in models])
 
 
+def jsonize_model(model):
+    """Return a single model instance as a JSON object."""
+    return json.dumps(dictify(model))
+
+
+class HashIds(hashids.Hashids):
+    """
+    HashID generator for our resources.  Database-assigned IDs are
+    hashed/obfuscated to avoid leaking implementation details and creating
+    unintentional expectations around resource identification.q
+    cf. http://hashids.org
+    """
+    def __init__(self, salt, min_length=5):
+        super(HashIds, self).__init__(
+            salt=';'.join(['sagittarius', salt]),
+            min_length=min_length)
+
+
+class Representable:
+    """
+    A base class for Models that generically generates a String representation
+    of the model and its properties.
+    """
+    def __repr__(self):
+        def repr_attr(k):
+            return '%s=%s' % (k, getattr(self, k))
+        reprified_attrs = [repr_attr(k) for k in iter(sorted(self.__dict__.keys()))
+                           if not k.startswith('_')]
+        if len(reprified_attrs) == 0:
+            attrs_repr = '<no instance attributes>'
+        else:
+            attrs_repr = ', '.join(reprified_attrs)
+        return '<%s: %s>' % (self.__class__.__name__, attrs_repr)
+
+
+class ResourceMetaClass(type(db.Model)):
+    """
+    A metaclass that injects the identifier fields that should be present on
+    all Models.
+    """
+    def __new__(metacls, clsname,  parents, attrs):
+        attrs['id'] = Column(Integer, primary_key=True)
+        attrs['obfuscated_id'] = Column(String(15), unique=True)
+        return super(ResourceMetaClass, metacls).__new__(
+            metacls, clsname, (Representable,) + parents, attrs)
+
+
 class Project(db.Model):
-    __tablename__ = 'projects'
-    id = Column('project_id', Integer, primary_key=True)
+    __metaclass__ = ResourceMetaClass
+    __tablename__ = 'project'
+    __hashidgen__ = HashIds('Project')
+
     name = Column(String(80), unique=True)
     sample_mask = Column(String(64), unique=False)
     # objects forward-related to project
-    samples = relationship('Sample',
-                           backref='project',
-                           lazy='dynamic')
-    # representation of the project
-    def __repr__(self):
-        return '<Project {id:}: {name:}>'.format(id=self.id, name=self.name)
+    samples = relationship(
+        'Sample', backref='project', lazy='dynamic')
 
 
 def get_projects():
@@ -43,79 +162,70 @@ def get_projects():
 
 
 def add_project(name, sample_mask):
-    """Adds a new project."""
-    p = Project(name=name, sample_mask=sample_mask)
+    """
+    Adds a new project.
+    """
     try:
         _ = Project.query.first()
     except OperationalError:
         db.create_all()
-    except IntegrityError:
-        msg = 'A Project named "{}" already exists.'.format(name)
-        raise IntegrityError(msg)
-    db.session.add(p)
-    db.session.commit()
-    return p.id
+    p = Project(name=name, sample_mask=sample_mask)
+    with_transaction(db.session, lambda session: session.add(p))
+    return jsonize_model(Project.query.filter_by(id=p.id).one())
 
 
 class Sample(db.Model):
-    __tablename__ = 'samples'
-    id = Column('sample_id', Integer, primary_key=True, autoincrement=True)
+    __metaclass__ = ResourceMetaClass
+    __tablename__ = 'sample'
+    __hashidgen__ = HashIds('Sample')
+
     name = Column(String(80), unique=True)
     # to what project does this sample belong
-    project_id = Column(Integer, ForeignKey('projects.project_id'))
+    _project_id = Column('project_id', Integer, ForeignKey('project.id'))
     # objects forward-related to sample
-    sample_stages = relationship('SampleStage',
-                                 backref='sample',
-                                 lazy='dynamic')
-    # representation of the sample
-    def __repr__(self):
-        return '<Sample {id:}: {name:}, project {project_id:}>'.format(
-            id=self.id, name=self.name, project_id=self.project_id)
+    sample_stages = relationship(
+        'SampleStage', backref='sample', lazy='dynamic')
+
+    @property
+    def project_id(self):
+        return self.project.obfuscated_id
 
 
-def get_samples(project_id=None):
+def get_samples(project_id):
     """
-    Returns a newline-separated JSON of all samples in a given project.
+    Returns a JSON array of the samples in a given project.
     """
-    try:
-        if project_id is None:
-            samples = Sample.query.all()
-        else:
-            samples = Sample.query.filter_by(project_id=project_id).all()
-    except OperationalError:
-        return ''
-    return '\n'.join([jsonize(s) for s in samples])
+    p = Project.query.filter_by(id=project_id).first()
+    if p is None:
+        msg = 'Project {} was not found.'.format(project_id)
+        raise NoResultFound(msg)
+    return jsonize_models(Sample.query.filter_by(project_id=p.id).all())
 
 
 def add_sample(project_id, name):
-    """Adds a new sample."""
-    p = Project.query.filter_by(id=project_id).first()
+    """
+    Adds a new sample.
+    """
+    p = Project.query.filter_by(obfuscated_id=project_id).first()
     if p is None:
-        msg = 'Project ID {} was not found.'.format(project_id)
+        msg = 'Project "%s" was not found.' % project_id
         raise NoResultFound(msg)
     s = Sample(name=name, project=p)
-    try:
-        db.session.add(s)
-        db.session.commit()
-    except IntegrityError:
-        msg = 'A Sample named "{}" already exists.'.format(name)
-        raise IntegrityError(msg)
-    return s.id
+    with_transaction(db.session, lambda session: session.add(s))
+    return jsonize_model(Sample.query.filter_by(id=s.id).one())
 
 
 class Method(db.Model):
-    __tablename__ = 'methods'
-    id = Column('method_id', Integer, primary_key=True)
+    __metaclass__ = ResourceMetaClass
+    __tablename__ = 'method'
+    __hashidgen__ = HashIds('Method')
+
     name = Column(String(80), unique=True)
     description = Column(String(80), unique=False)
+
     # objects forward-related to method
-    sample_stages = relationship('SampleStage',
-                                 backref='method',
-                                 lazy='dynamic')
-    # representation of the method
-    def __repr__(self):
-        return '<Method {id:}: {name:}, {descr:}>'.format(
-            id=self.id, name=self.name, descr=self.description)
+    sample_stages = relationship(
+        'SampleStage', backref='method', lazy='dynamic')
 
 
 def get_methods():
@@ -131,35 +241,36 @@ def get_methods():
 
 def add_method(name, description):
     """Adds a new method."""
-    m = Method(name=name, description=description)
     try:
         _ = Method.query.first()
     except OperationalError:
         db.create_all()
-    except IntegrityError:
-        msg = 'A Method named "{}" already exists.'.format(name)
-        raise IntegrityError(msg)
-    db.session.add(m)
-    db.session.commit()
-    return m.id
+    m = Method(name=name, description=description)
+    with_transaction(db.session, lambda session: session.add(m))
+    return jsonize_model(Method.query.filter_by(id=m.id).one())
 
 
 class SampleStage(db.Model):
-    __tablename__ = 'sample_stages'
-    id = Column('sample_stage_id', Integer, primary_key=True)
+    __metaclass__ = ResourceMetaClass
+    __tablename__ = 'sample_stage'
+    __hashidgen__ = HashIds('SampleStage')
+
     annotation = Column(Text, unique=False)
     alt_id = Column(Integer, unique=False)
     # relationships
-    sample_id = Column(Integer, ForeignKey('samples.sample_id'))
-    method_id = Column(Integer, ForeignKey('methods.method_id'))
+    _sample_id = Column('sample_id', Integer, ForeignKey('sample.id'))
+    _method_id = Column('method_id', Integer, ForeignKey('method.id'))
     # objects forward-related to sample stage
-    sample_stage_files = relationship('SampleStageFile',
-                                      backref='sample_stage',
-                                      lazy='dynamic')
-    # representation of the sample stage
-    def __repr__(self):
-        return '<Sample Stage {id:}: {ann:}, alt={alt:}>'.format(
-            id=self.id, ann=self.annotation, alt=self.alt_id)
+    sample_stage_files = relationship(
+        'SampleStageFile', backref='sample_stage', lazy='dynamic')
+
+    @property
+    def sample_id(self):
+        return self.sample.obfuscated_id
+
+    @property
+    def method_id(self):
+        return self.method.obfuscated_id
 
 
 def get_stages(sample_id=None, method_id=None):
@@ -185,19 +296,18 @@ def add_stage(sample_id, method_id, annotation, alt_id=None):
         _ = SampleStage.query.first()
     except OperationalError:
         db.create_all()
-    s = Sample.query.filter_by(id=sample_id).first()
+    s = Sample.query.filter_by(obfuscated_id=sample_id).first()
     if s is None:
         msg = 'Sample ID {} was not found.'.format(sample_id)
         raise NoResultFound(msg)
-    m = Method.query.filter_by(id=method_id).first()
+    m = Method.query.filter_by(obfuscated_id=method_id).first()
     if m is None:
         msg = 'Method ID {} was not found.'.format(method_id)
         raise NoResultFound(msg)
-    ss = SampleStage(annotation=annotation, sample=s, method=m,
-                     alt_id=alt_id)
-    db.session.add(ss)
-    db.session.commit()
-    return ss.id
+    ss = SampleStage(
+        annotation=annotation, sample=s, method=m, alt_id=alt_id)
+    with_transaction(db.session, lambda session: session.add(ss))
+    return jsonize_model(SampleStage.query.filter_by(id=ss.id).one())
 
 
 class FileStatus(object):
@@ -205,14 +315,21 @@ class FileStatus(object):
     incomplete = 1
 
 class SampleStageFile(db.Model):
-    __tablename__ = 'sample_stage_files'
-    id = Column('sample_stage_file_id', Integer, primary_key=True)
+    __metaclass__ = ResourceMetaClass
+    __tablename__ = 'sample_stage_file'
+    __hashidgen__ = HashIds('SampleStageFile')
+
     file_repr = Column(Text, unique=True)
     relative_file_path = Column(Text, unique=True)
     status = Column(Integer, unique=False)
     # relationships
-    sample_stage_id = Column(Integer,
-                             ForeignKey('sample_stages.sample_stage_id'))
+    _sample_stage_id = Column(
+        'sample_stage_id', Integer, ForeignKey('sample_stage.id'))
+
+    @property
+    def sample_stage_id(self):
+        return self.sample_stage.obfuscated_id
+
     # create a sample stage file object
     def __init__(self, sample_stage, status=FileStatus.incomplete):
         kwds = {}
@@ -242,6 +359,7 @@ class SampleStageFile(db.Model):
                '{file:} ({relpath:}), status={stat:}>'.format(
                     id=self.id, file=self.file_repr,
                     relpath=self.relative_file_path, stat=self.status)
+
 
 def create_upload_filename(*args, **kwds):
     counter = 0
@@ -288,6 +406,5 @@ def add_file(sample_stage_id):
         msg = 'SampleStage ID {} was not found.'.format(sample_stage_id)
         raise NoResultFound(msg)
     ssf = SampleStageFile(sample_stage=ss)
-    db.session.add(ssf)
-    db.session.commit()
-    return ssf.id
+    with_transaction(db.session, lambda session: session.add(ssf))
+    return jsonize_model(SampleStageFile.query.filter_by(id=ssf.id))

--- a/app/models.py
+++ b/app/models.py
@@ -13,7 +13,8 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm.exc        import NoResultFound, MultipleResultsFound
 from urllib                    import quote
 
-from app import app, db
+from app        import app, db
+from exceptions import NotFound
 
 
 BAD_URI_PAT  = re.compile("%.{2}|\/|_")
@@ -195,11 +196,11 @@ def get_samples(project_id):
     """
     Returns a JSON array of the samples in a given project.
     """
-    p = Project.query.filter_by(id=project_id).first()
+    p = Project.query.filter_by(obfuscated_id=project_id).first()
     if p is None:
         msg = 'Project {} was not found.'.format(project_id)
-        raise NoResultFound(msg)
-    return jsonize_models(Sample.query.filter_by(project_id=p.id).all())
+        raise NotFound('Sample', project_id)
+    return jsonize_models(Sample.query.filter_by(_project_id=p.id).all())
 
 
 def add_sample(project_id, name):

--- a/app/views.py
+++ b/app/views.py
@@ -1,21 +1,25 @@
+
+from flask import jsonify, request
 from app import app, models
-# from flask import render_template
+from exceptions import NotFound
 
+# ------------------------------------------------------------ api routes --- #
 
-@app.route('/')
-def root():
-    return 'Hello, world!'
-
-
-@app.route('/projects')
-def projects():
+@app.route('/projects', methods=['GET'])
+def get_projects():
     return models.get_projects()
 
 
-@app.route('/methods')
-def methods():
+@app.route('/projects/<project>/samples', methods=['GET'])
+def get_project_samples(project):
+    return models.get_samples(project.split('-')[0])
+
+
+@app.route('/methods', methods=['GET'])
+def get_methods():
     return models.get_methods()
 
+# --------------------------------------------------------- static routes --- #
 
 @app.route('/index')
 def index():
@@ -29,3 +33,10 @@ def index():
         return ifs.read()
     # return render_template(ifile)
 
+# --------------------------------------------- errors and error handlers --- #
+
+@app.errorhandler(NotFound)
+def handle_resource_not_found(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -4,6 +4,7 @@ import pytest
 import tempfile
 
 import app
+import app.models as models
 
 @pytest.fixture(scope='function')
 def ws(request):
@@ -23,3 +24,10 @@ def ws(request):
         os.unlink(fn)
     request.addfinalizer(fin)
     return inst
+
+
+@pytest.fixture(scope='function')
+def sample(ws):
+    models.add_project(name='Manhattan', sample_mask='man-###')
+    models.add_sample(project_id='PqrX9', name='sample 1')
+    models.add_method(name='X-ray tomography', description='Placeholder description.')

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -1,0 +1,25 @@
+
+import os
+import pytest
+import tempfile
+
+import app
+
+@pytest.fixture(scope='function')
+def ws(request):
+    flask_app = app.app.app
+    # Yuck!  Reeeally have to fix the app name!
+
+    fd, fn = tempfile.mkstemp()
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + fn
+    flask_app.config['TESTING'] = True
+    inst = flask_app.test_client()
+    with flask_app.app_context():
+        app.models.db.create_all()
+        pass
+
+    def fin():
+        os.close(fd)
+        os.unlink(fn)
+    request.addfinalizer(fin)
+    return inst

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -6,13 +6,8 @@ import tempfile
 import app
 
 from app      import models
-from fixtures import ws
+from fixtures import sample, ws
 from utils    import decode_json_string
-
-
-def test_0(ws):
-    rsp = ws.get('/')
-    assert rsp.data == b'Hello, world!'
 
 
 def test_0_projects(ws):
@@ -28,10 +23,29 @@ def test_1_projects(ws):
     assert len(rsp) == 1
     assert {'id':'PqrX9-project-3', 'name': name, 'sample-mask': mask} == rsp[0]
 
+
 def test_1_methods(ws):
     name = 'Method 1'
     desc = 'Placeholder description.'
     models.add_method(name, desc)
     rsp = decode_json_string(ws.get('/methods').data)
-    assert len(rsp) == 1
-    assert {'id':'XZOQ0-method-1', 'name':name, 'description':desc} == rsp[0]
+    assert [{'id':'XZOQ0-method-1', 'name':name, 'description':desc}] \
+        == rsp
+
+def test_get_sample_with_context(ws, sample):
+    rsp = decode_json_string(ws.get('/projects/PqrX9-project-0/samples').data)
+    assert [{'id'   : 'OQn6Q-sample-1',
+             'name' : 'sample 1'}] \
+        == rsp
+
+
+def test_get_sample_without_context(ws, sample):
+    rsp = decode_json_string(ws.get('/projects/PqrX9/samples').data)
+    assert [{'id'   : 'OQn6Q-sample-1',
+             'name' : 'sample 1'}] \
+        == rsp
+
+
+def test_sample_project_not_found(ws, sample):
+    rsp = ws.get('/projects/00000-project-X/samples')
+    assert rsp.status_code == 404

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -1,36 +1,13 @@
 
-from StringIO import StringIO
-import json
 import os
 import pytest
 import tempfile
 
 import app
-from app import models
 
-
-@pytest.fixture(scope='function')
-def ws(request):
-    flask_app = app.app.app
-    # Yuck!  Reeeally have to fix the app name!
-
-    fd, fn = tempfile.mkstemp()
-    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + fn
-    flask_app.config['TESTING'] = True
-    inst = flask_app.test_client()
-    with flask_app.app_context():
-        # db initialization goes here
-        pass
-
-    def fin():
-        os.close(fd)
-        os.unlink(fn)
-    request.addfinalizer(fin)
-    return inst
-
-
-def decode_json_string(s):
-    return json.load(StringIO(s))
+from app      import models
+from fixtures import ws
+from utils    import decode_json_string
 
 
 def test_0(ws):
@@ -40,21 +17,21 @@ def test_0(ws):
 
 def test_0_projects(ws):
     rsp = ws.get('/projects')
-    assert rsp.data is ''
+    assert '[]' == rsp.data
 
 
 def test_1_projects(ws):
-    name = 'project3'
+    name = 'Project 3'
     mask = '###'
     models.add_project(name, mask)
     rsp = decode_json_string(ws.get('/projects').data)
     assert len(rsp) == 1
-    assert rsp[0] == {'id': 1, 'name': name, 'sample_mask': mask}
+    assert {'id':'PqrX9-project-3', 'name': name, 'sample-mask': mask} == rsp[0]
 
 def test_1_methods(ws):
-    name = 'method0'
-    desc = 'placeholder description'
+    name = 'Method 1'
+    desc = 'Placeholder description.'
     models.add_method(name, desc)
     rsp = decode_json_string(ws.get('/methods').data)
     assert len(rsp) == 1
-    assert rsp[0] == {'id':1, 'name':name, 'description':desc}
+    assert {'id':'XZOQ0-method-1', 'name':name, 'description':desc} == rsp[0]

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,10 +1,87 @@
 
+import os
 import pytest
+import tempfile
 
-from app.models import Project
-from app.models import dictify
+from sqlalchemy import Column, Integer
+
+import app
+import app.models as models
+
+from app.models import db
+from fixtures   import ws
+from utils      import decode_json_string
 
 
 def test_dictify():
-    p = Project(id=0, name='project', sample_mask='###')
-    assert dictify(p) == {'id':0, 'name':'project', 'sample_mask':'###'}
+    p = models.Project(id=1, obfuscated_id='5QMVv', name='project', sample_mask='###')
+    assert {'id'          : '5QMVv-project',
+            'name'        : 'project',
+            'sample-mask' : '###'} \
+        == models.dictify(p)
+
+
+def test_dictify_no_name():
+    class NoName(db.Model):
+        __metaclass__ = models.ResourceMetaClass
+        __tablename__ = 'no-name'
+    assert {'id':'5QMVv'} \
+        == models.dictify(NoName(id=1, obfuscated_id='5QMVv'))
+
+
+def test_uri_name():
+    spec = {'foobar'    : 'foobar',
+            'fooBar'    : 'foobar',
+            'foo bar'   : 'foo-bar',
+            'f o o'     : 'f-o-o',
+            'foo   bar' : 'foo-bar',
+            'foo ~ bar' : 'foo-bar'}
+    for kv in iter(spec.items()):
+        assert kv[1] == models.uri_name(kv[0])
+
+
+def test_add_project(ws):
+    assert {'id'          : 'PqrX9-manhattan',
+            'name'        : 'Manhattan',
+            'sample-mask' : 'man-###'} \
+        == decode_json_string(
+            models.add_project('Manhattan', 'man-###'))
+
+
+def test_add_method(ws):
+    assert {'id'          : 'XZOQ0-x-ray-tomography',
+            'name'        : 'X-ray tomography',
+            'description' : 'Placeholder description.'} \
+        == decode_json_string(
+            models.add_method(name='X-ray tomography',
+                              description='Placeholder description.'))
+
+
+def test_add_sample(ws):
+    models.add_project(name='Manhattan', sample_mask='man-###')
+    assert {'id'   : 'OQn6Q-sample-1',
+            'name' : 'sample 1'} \
+        == decode_json_string(
+            models.add_sample(project_id='PqrX9', name='sample 1'))
+    assert 1 == \
+        models.db.engine.execute(
+            'select project_id from sample where id=1').fetchone()[0]
+
+
+def test_add_sample_stage(ws):
+    models.add_project(name='Manhattan', sample_mask='man-###')
+    models.add_sample(project_id='PqrX9', name='sample 1')
+    models.add_method(name='X-ray tomography', description='Placeholder description.')
+    assert {'id'         : 'Drn1Q',
+            'annotation' : 'Annotation',
+            'alt-id'     : None} \
+        == decode_json_string(
+            models.add_stage(sample_id='OQn6Q',
+                             method_id='XZOQ0',
+                             annotation='Annotation'))
+    assert 1 == \
+        models.db.engine.execute(
+            'select sample_id from sample_stage where id=1').fetchone()[0]
+    assert 1 == \
+        models.db.engine.execute(
+            'select method_id from sample_stage where id=1').fetchone()[0]

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,6 @@
+
+from StringIO import StringIO
+import json
+
+def decode_json_string(s):
+    return json.load(StringIO(s))


### PR DESCRIPTION
This is a change to the way that resources are represented in the API; specifically, they are identified by name, rather than by ID.  ID's leak implementation (DB autonumber) and don't make for very [good RESTful URIs](http://blog.2partsmagic.com/restful-uri-design/); e.g. using

```
$ curl http://sagittariidae/projects/inconel
```

rather than:

```
$ curl "http://sagittariidae/projects/9
```

provides more context, a more grokkable API, and provides more readable traces on both server and client.  Like the internal properties of a model (those prefixed with '__'), IDs are now also stripped out of the JSON-serialised form.  A function for turning a name into a URI-friendly resource name has been added and is used when new resources are created; in general it turns "A new Resource" into "a-new-resource".

This also adds a new route to retrieve samples.
