### PR TITLE
Move JSONising out of `models` module.

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1,23 +1,28 @@
 
 from flask import jsonify, request
-from app import app, models
+from app import app, db, models
 from exceptions import NotFound
+
+import json
+import re
+
+from urllib import quote
 
 # ------------------------------------------------------------ api routes --- #
 
 @app.route('/projects', methods=['GET'])
 def get_projects():
-    return models.get_projects()
+    return jsonize(models.get_projects())
 
 
 @app.route('/projects/<project>/samples', methods=['GET'])
 def get_project_samples(project):
-    return models.get_samples(project.split('-')[0])
+    return jsonize(models.get_samples(project.split('-')[0]))
 
 
 @app.route('/methods', methods=['GET'])
 def get_methods():
-    return models.get_methods()
+    return jsonize(models.get_methods())
 
 # --------------------------------------------------------- static routes --- #
 
@@ -40,3 +45,79 @@ def handle_resource_not_found(error):
     response = jsonify(error.to_dict())
     response.status_code = error.status_code
     return response
+
+# -------------------------------------------------- custom JSON encoding --- #
+
+class DBModelJSONEncoder(json.JSONEncoder):
+
+    BAD_URI_PAT  = re.compile("%.{2}|\/|_")
+    COLLAPSE_PAT = re.compile("-{2,}")
+
+    def _uri_name(self, name):
+        """
+        Convert the name of a resource (like a project or sample) into a
+        URI-friendly form.  This function has strong opinions about what a
+        "good" URI ID is, and will complain if the ID cannot be rendered in
+        an acceptable form.  In particular, it should not contain any
+        characters that need to be escaped; cf. `urllib.quote()`.
+        """
+        # URI-escape special characters
+        new_name = quote(name.lower().replace(" ", "-"))
+        # Convert escapes into underscores; i.e. foo%20bar -> foo-bar
+        new_name = re.sub(self.BAD_URI_PAT, '-', new_name)
+        # Collapse multiple consecutive hyphens; i.e. foo---bar -> foo-bar
+        new_name = re.sub(self.COLLAPSE_PAT, '-', new_name)
+        # And return our pretty new identifier
+        return new_name
+
+    def _dictify(self, model, exclude={}):
+        """
+        Return a model as a dictionary. 'Private' attributes are removed and
+        underscores are replaced with more hyphens in attribute names, making
+        for more aesthetically pleasing HTTP data maps.
+        """
+        assert hasattr(model, 'id')
+        assert model.id is not None, 'Model\'s ID may not be None'
+        assert hasattr(model, 'obfuscated_id')
+        assert model.obfuscated_id is not None, 'Model\'s obfuscated ID may not be None'
+
+        def tr(kv):
+            return (kv[0].replace('_', '-'), kv[1])
+        return dict(tr(kv) for kv in iter(model.__dict__.items())
+                    if (not (kv[0].startswith('_') or (kv[0] in exclude))))
+
+    def strip_private_fields(self, d):
+        del d['obfuscated-id']
+        return d
+
+    def _encodeProject(self, p):
+        d = self._dictify(p)
+        d['id'] = '-'.join([d['obfuscated-id'], self._uri_name(d['name'])])
+        return self.strip_private_fields(d)
+
+    def _encodeSample(self, s):
+        d = self._dictify(s, {'project'})
+        d['project'] = '-'.join(
+            [s.project.obfuscated_id, self._uri_name(s.project.name)])
+        d['id'] = '-'.join([d['obfuscated-id'], self._uri_name(d['name'])])
+        return self.strip_private_fields(d)
+
+    def _encodeMethod(self, m):
+        d = self._dictify(m)
+        d['id'] = '-'.join([d['obfuscated-id'], self._uri_name(d['name'])])
+        return self.strip_private_fields(d)
+
+    def _encodeModel(self, m):
+        return self.strip_private_fields(self._dictify(m))
+
+    def default(self, thing):
+        f = {models.Project : self._encodeProject,
+             models.Sample  : self._encodeSample,
+             models.Method  : self._encodeMethod,
+             db.Model       : self._encodeModel
+        }.get(thing.__class__, lambda x: json.JSONEncoder.default(self, x))
+        return f(thing)
+
+
+def jsonize(x):
+    return json.dumps(x, cls=DBModelJSONEncoder)

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -5,6 +5,8 @@ import tempfile
 
 import app
 import app.models as models
+import app.views as views
+
 
 @pytest.fixture(scope='function')
 def ws(request):
@@ -28,6 +30,15 @@ def ws(request):
 
 @pytest.fixture(scope='function')
 def sample(ws):
-    models.add_project(name='Manhattan', sample_mask='man-###')
-    models.add_sample(project_id='PqrX9', name='sample 1')
-    models.add_method(name='X-ray tomography', description='Placeholder description.')
+    project = models.add_project(name='Manhattan', sample_mask='man-###')
+    sample = models.add_sample(project_id='PqrX9', name='sample 1')
+    method = models.add_method(name='X-ray tomography', description='Placeholder description.')
+    return {'app'     : ws,
+            'project' : project,
+            'sample'  : sample,
+            'method'  : method}
+
+
+@pytest.fixture(scope='module')
+def json_encoder(request):
+    return views.DBModelJSONEncoder()

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -3,25 +3,22 @@ import os
 import pytest
 import tempfile
 
-import app
-
 from app      import models
 from fixtures import sample, ws
 from utils    import decode_json_string
 
 
-def test_0_projects(ws):
+def test_no_projects(ws):
     rsp = ws.get('/projects')
-    assert '[]' == rsp.data
+    assert [] == decode_json_string(rsp.data)
 
 
-def test_1_projects(ws):
-    name = 'Project 3'
-    mask = '###'
-    models.add_project(name, mask)
+def test_1_projects(ws, sample):
     rsp = decode_json_string(ws.get('/projects').data)
-    assert len(rsp) == 1
-    assert {'id':'PqrX9-project-3', 'name': name, 'sample-mask': mask} == rsp[0]
+    assert [{'id':'PqrX9-manhattan',
+             'name': 'Manhattan',
+             'sample-mask': 'man-###'}] \
+        == rsp
 
 
 def test_1_methods(ws):
@@ -32,17 +29,20 @@ def test_1_methods(ws):
     assert [{'id':'XZOQ0-method-1', 'name':name, 'description':desc}] \
         == rsp
 
+
 def test_get_sample_with_context(ws, sample):
     rsp = decode_json_string(ws.get('/projects/PqrX9-project-0/samples').data)
-    assert [{'id'   : 'OQn6Q-sample-1',
-             'name' : 'sample 1'}] \
+    assert [{'id'      : 'OQn6Q-sample-1',
+             'name'    : 'sample 1',
+             'project' : 'PqrX9-manhattan'}] \
         == rsp
 
 
 def test_get_sample_without_context(ws, sample):
     rsp = decode_json_string(ws.get('/projects/PqrX9/samples').data)
-    assert [{'id'   : 'OQn6Q-sample-1',
-             'name' : 'sample 1'}] \
+    assert [{'id'      : 'OQn6Q-sample-1',
+             'name'    : 'sample 1',
+             'project' : 'PqrX9-manhattan'}] \
         == rsp
 
 

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -1,0 +1,39 @@
+
+import pytest
+
+from sqlalchemy import Column, Integer
+
+from app.models import Project, Sample
+from app.models import db
+from app.views  import jsonize
+from utils      import decode_json_string
+
+from fixtures   import json_encoder
+
+
+def test_dictify(json_encoder):
+    p = Project(id=1, obfuscated_id='5QMVv', name='project', sample_mask='###')
+    assert {'id'            : 1,
+            'obfuscated-id' : '5QMVv',
+            'name'          : 'project',
+            'sample-mask'   : '###'} \
+            == json_encoder._dictify(p)
+
+
+def test_dictify_exclusions(json_encoder):
+    p = Project(id=1, obfuscated_id='5QMVv', name='project', sample_mask='###')
+    assert {'obfuscated-id' : '5QMVv',
+            'sample-mask'   : '###'} \
+            == json_encoder._dictify(p, {'id', 'name'})
+
+
+def test_uri_name(json_encoder):
+    spec = {'foobar'    : 'foobar',
+            'fooBar'    : 'foobar',
+            'foo bar'   : 'foo-bar',
+            'f o o'     : 'f-o-o',
+            'foo   bar' : 'foo-bar',
+            'foo ~ bar' : 'foo-bar'}
+    for kv in iter(spec.items()):
+        assert kv[1] == json_encoder._uri_name(kv[0])
+

--- a/test/utils.py
+++ b/test/utils.py
@@ -2,5 +2,6 @@
 from StringIO import StringIO
 import json
 
+
 def decode_json_string(s):
     return json.load(StringIO(s))


### PR DESCRIPTION
That the API returns data as JSON documents is a presentation issue and
not something about which the persistance layer should be concerned.
This also makes it easier to re-use the functions that retrieve model
instances from within the module.

While I'm not wild about leaking the db model classes into the
presentation layer, it does make parts of the serialisation easier (like
the custom project name serialization for samples), but at the cost of
tighter coupling between the presentation layer and the implementation
of the persistance framework (SQLAlchemy).

But unfortunately, while it is easy to extend Python's json module to
new types, it is hard to extend for built-in types.  So using dicts
instead of the models to communicate between the API and persistance
layers isn't easily possible (and would require way more monkey-patching
than I would consider reasonable).  The alternative is to create a class
hierarchy that parallels/wraps the Model classes used by the persistance
layer.

At this point though that seems like overkill.
