### PR TITLE
Remove defunct methods.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -45,16 +45,6 @@ def with_transaction(session, f):
         raise e
 
 
-def jsonize_models(models):
-    """Return a list of model instances as a JSON array."""
-    return json.dumps([dictify(m) for m in models])
-
-
-def jsonize_model(model):
-    """Return a single model instance as a JSON object."""
-    return json.dumps(dictify(model))
-
-
 class HashIds(hashids.Hashids):
     """
     HashID generator for our resources.  Database-assigned IDs are


### PR DESCRIPTION
These methods that were used to JSONise models should have been removed
from the `models` module when the responsibility for JSONising was moved
from `models` to `views`.

cf. commit 73d170b
