### PR TITLE
Require and validate upload checksum.

### DIFF
--- a/app/checksum.py
+++ b/app/checksum.py
@@ -1,0 +1,65 @@
+
+import hashlib
+
+import file
+import http
+
+
+DIGESTERS = {'sha256': lambda: hashlib.sha256() }
+
+
+class ChecksumError(Exception):
+    status_code = http.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+class UnsupportedChecksumMethod(ChecksumError):
+    def __init__(self, method):
+        self.method  = method
+        self.message = 'The checksum method "%s" is not supported; use one of: %s' % (method, DIGESTERS.keys())
+    def __str__(self):
+        return self.message
+
+
+class ChecksumMismatch(ChecksumError):
+    def __init__(self, f, method, received, computed):
+        self.file     = f
+        self.method   = method
+        self.received = received
+        self.computed = computed
+        self.message  = 'Checksum mismatch for %s using method %s; received=%s, computed=%s' % (f, method, received, computed)
+    def __str__(self):
+        return self.message
+
+
+def get_digester(method):
+    """
+    Retrieve a digester that implements the checksum `method`.  Returns an
+    instance of a hashlib digester.
+    """
+    digesterfn = DIGESTERS[method]
+    if digesterfn is None:
+        raise UnsupportedChecksumMethod(method)
+    else:
+        return digesterfn()
+
+
+def generate_checksum(f, method):
+    """
+    A convenience function to produce a checksum for an entire file.
+    Returns the digest as a hex-encoded string.
+    """
+    digester = get_digester(method)
+    file.FileProcessor(f, lambda data: digester.update(data)).process()
+    return digester.hexdigest()
+
+
+def validate_checksum(f, method, received):
+    """
+    A convenience method to generate and validate a checksum for an entire
+    file. Raises a `ChecksumMismatch` exception if the `received` and generated
+    checksums do not match.
+    Always returns `None`.
+    """
+    computed = generate_checksum(f, method)
+    if computed != received:
+        raise ChecksumMismatch(f, method, received, computed)

--- a/app/file.py
+++ b/app/file.py
@@ -34,3 +34,18 @@ def iswritable(name):
 def touch(name, dirmode=0777):
     os.makedirs(os.path.dirname(name), dirmode)
     open(name, 'wa').close()
+
+class FileProcessor(object):
+    DEFAULT_READ_BLOCKSIZE = 65536
+
+    def __init__(self, fpath, fn, read_blocksize=DEFAULT_READ_BLOCKSIZE):
+        self.fpath = fpath
+        self.fn = fn
+        self.blocksize = read_blocksize
+
+    def process(self):
+        with open(self.fpath, 'r') as f:
+            buf = f.read(self.blocksize)
+            while len(buf) > 0:
+                self.fn(buf)
+                buf = f.read(self.blocksize)


### PR DESCRIPTION
Clients must mow provide a checksum for the uploaded file.

For large files this takes long enough that it should not be on the synchronous path; it risks timeouts on the client-side, and we tie up Werkzeug worker threads unnecessarily.  I'm addressing this in the Clojure version.
